### PR TITLE
Remove check for get_fields to fix loading order

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -15,6 +15,4 @@ function wp_api_encode_acf($data,$post,$context){
     return $data;
 }
 
-if( function_exists('get_fields') ){
-    add_filter('json_prepare_post', 'wp_api_encode_acf', 10, 3);
-}
+add_filter('json_prepare_post', 'wp_api_encode_acf', 10, 3);


### PR DESCRIPTION
This is check is unnecessary because the add_filter option just returns false if we're unable to hook into that function.
It will also cause the plugin to fail if it loads before Advanced Custom Fields
